### PR TITLE
Encode POM string to utf-8 before use

### DIFF
--- a/pymaven/pom.py
+++ b/pymaven/pom.py
@@ -420,7 +420,8 @@ class Pom(Artifact):
         creation time, use that client to fetch the POM artifact data remotely.
         """
         if self._client is None:
-            return etree.fromstring(EMPTY_POM.format(self), parser=POM_PARSER)
+            _pom_data = EMPTY_POM.format(self)
+            return etree.fromstring(_pom_data.encode('utf-8'), parser=POM_PARSER)
 
         contents = self._client.get_artifact(self.coordinate).contents
         with contents as fh:

--- a/tests/test_pom.py
+++ b/tests/test_pom.py
@@ -47,6 +47,25 @@ class TestPom(unittest.TestCase):
         client.get_artifact.side_effect = side_effect
         return client
 
+    def test_fromstring_without_client(self):
+        """Test that a POM object can be created from a string without a client"""
+        pom = Pom.fromstring("foo:bar:1", FOO_BAR_1_POM)
+        assert pom.parent.group_id == "foo"
+        assert pom.parent.artifact_id == "parent"
+        assert pom.parent.version == "1"
+        assert pom.parent.properties["groupId"] == "foo"
+        assert pom.parent.properties["artifactId"] == "parent"
+        assert pom.parent.properties["version"] == "1"
+        assert pom.parent.properties["project.groupId"] == "foo"
+        assert pom.parent.properties["project.artifactId"] == "parent"
+        assert pom.parent.properties["project.version"] == "1"
+        assert pom.parent.properties["pom.groupId"] == "foo"
+        assert pom.parent.properties["pom.artifactId"] == "parent"
+        assert pom.parent.properties["pom.version"] == "1"
+        assert pom.properties["parent.groupId"] == "foo"
+        assert pom.properties["parent.artifactId"] == "parent"
+        assert pom.properties["parent.version"] == "1"
+
     def test_parent(self):
         """Test pom parent processing"""
         client = self._mock_client(FOO_PARENT_1_POM)


### PR DESCRIPTION
This PR fixes the issue described in https://github.com/nexB/scancode-toolkit/issues/2220 by encoding the formatted string containing POM data into utf-8 before passing it along to `lxml.etree`. A test has been added to ensure that basic functionality of `Pom.fromstring`.